### PR TITLE
[html-upgrade] properly port Ruby content

### DIFF
--- a/html-utils/src/main/resources/xml/xslt/html5-upgrade.xsl
+++ b/html-utils/src/main/resources/xml/xslt/html5-upgrade.xsl
@@ -29887,7 +29887,7 @@
       <xsl:copy-of select="@class|@accesskey|@contenteditable|@contextmenu|@dir|@draggable|@dropzone|@hidden|@id|@lang|@spellcheck|@style|@tabindex|@title|@translate|@onabort|@onblur|@oncancel|@oncanplay|@oncanplaythrough|@onchange|@onclick|@onclose|@oncontextmenu|@oncuechange|@ondblclick|@ondrag|@ondragend|@ondragenter|@ondragleave|@ondragover|@ondragstart|@ondrop|@ondurationchange|@onemptied|@onended|@onerror|@onfocus|@oninput|@oninvalid|@onkeydown|@onkeypress|@onkeyup|@onload|@onloadeddata|@onloadedmetadata|@onloadstart|@onmousedown|@onmousemove|@onmouseout|@onmouseover|@onmouseup|@onmousewheel|@onpause|@onplay|@onplaying|@onprogress|@onratechange|@onreset|@onscroll|@onseeked|@onseeking|@onselect|@onshow|@onstalled|@onsubmit|@onsuspend|@ontimeupdate|@onvolumechange|@onwaiting|@*[not(namespace-uri()=('','http://www.w3.org/1999/xhtml')) or starts-with(local-name(),'data-')]"/>
       <xsl:for-each select="*|text()|comment()">
          <xsl:choose>
-            <xsl:when test="self::*[not(namespace-uri()=('','http://www.w3.org/1999/xhtml'))]">
+            <xsl:when test="self::h:rp|self::h:rt|self::*[not(namespace-uri()=('','http://www.w3.org/1999/xhtml'))]">
                <xsl:copy>
                   <xsl:apply-templates select="."/>
                </xsl:copy>


### PR DESCRIPTION
Changed the (generated) html5-upgrade so that `rp` and `rt` children of `ruby` elements are preserved. We'll need to test and keep that when we work on the "manual" implementation of the upgrade.
