### PR TITLE
Fix html-to-fileset for 'data:' URIs

### DIFF
--- a/html-utils/src/main/resources/xml/xslt/html-to-fileset.xsl
+++ b/html-utils/src/main/resources/xml/xslt/html-to-fileset.xsl
@@ -6,17 +6,17 @@
     xmlns:pf="http://www.daisy.org/ns/pipeline/functions" xmlns:svg="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:m="http://www.w3.org/1998/Math/MathML"
     xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" exclude-result-prefixes="#all">
-    
+
     <xsl:import href="http://www.daisy.org/pipeline/modules/file-utils/xslt/uri-functions.xsl"/>
-    
+
     <xsl:strip-space elements="*"/>
     <xsl:output indent="yes"/>
-    
+
     <xsl:template match="text()"/>
-    
+
     <xsl:variable name="doc-base"
         select="if (/html/head/base[@href][1]) then resolve-uri(normalize-space(/html/head/base[@href][1]/@href),base-uri(/)) else base-uri(/)"/>
-    
+
     <xsl:template match="/*">
         <!--
         Builds a file set with all the resources referenced from the HTML.
@@ -27,8 +27,8 @@
             <xsl:apply-templates/>
         </d:fileset>
     </xsl:template>
-    
-    
+
+
     <xsl:template match="/processing-instruction('xml-stylesheet')">
         <xsl:variable name="href" select="replace(.,'^.*href=(&amp;apos;|&quot;)(.*?)\1.*$','$2')"/>
         <xsl:variable name="type" select="replace(.,'^.*type=(&amp;apos;|&quot;)(.*?)\1.*$','$2')"/>
@@ -40,7 +40,7 @@
             else '',false())"
         />
     </xsl:template>
-    
+
     <xsl:template match="link">
         <!--
             External resources: icon, prefetch, stylesheet + pronunciation
@@ -69,117 +69,119 @@
             </xsl:if>
         </xsl:if>
     </xsl:template>
-    
+
     <xsl:template match="style">
         <xsl:for-each select="f:get-css-resources(.,$doc-base)">
             <xsl:sequence select="f:fileset-entry(.,(),false())"/>
         </xsl:for-each>
     </xsl:template>
-    
+
     <xsl:template match="script[@src]">
         <xsl:sequence
             select="f:fileset-entry(@src,if (@type) then @type else 'text/javascript',false())"/>
     </xsl:template>
-    
+
     <xsl:template match="a[@href]">
         <!--FIXME add out-of-spine local XHTML resources-->
     </xsl:template>
-    
-    
+
+
     <xsl:template match="img[@src]">
-        <xsl:sequence
-            select="f:fileset-entry(@src,
+        <xsl:if test="not(pf:get-scheme(@src)='data')">
+            <xsl:sequence
+                select="f:fileset-entry(@src,
             if (matches(@src,'.*\.png$','i')) then 'image/png'
             else if (matches(@src,'.*\.jpe?g$','i')) then 'image/jpeg'
             else if (matches(@src,'.*\.gif$','i')) then 'image/gif'
             else if (matches(@src,'.*\.svg$','i')) then 'image/svg+xml'
             else (),false())"
-        />
+            />
+        </xsl:if>
     </xsl:template>
-    
+
     <xsl:template match="iframe[@src]">
         <!--TODO support iframe/@srcdoc -->
         <xsl:sequence select="f:fileset-entry(@src,'application/xhtml+xml',false())"/>
     </xsl:template>
-    
+
     <xsl:template match="embed[@src]">
         <xsl:sequence select="f:fileset-entry(@src,@type,false())"/>
     </xsl:template>
-    
+
     <xsl:template match="object[@data]">
         <xsl:sequence
             select="f:fileset-entry(@data,@type,f:is-audio(@data,@type) or f:is-video(@data,@type))"
         />
     </xsl:template>
-    
-    
+
+
     <xsl:template match="audio[@src]|video[@src]">
         <xsl:sequence select="f:fileset-entry(@src,(),true())"/>
     </xsl:template>
-    
+
     <xsl:template match="source">
         <xsl:sequence select="f:fileset-entry(@src,@type,true())"/>
     </xsl:template>
-    
+
     <xsl:template match="track">
         <xsl:sequence select="f:fileset-entry(@src,(),false())"/>
     </xsl:template>
-    
-    
+
+
     <!--–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––>
      |  SVG                                                                        |
     <|–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––-->
-    
+
     <!--See http://www.w3.org/TR/SVGTiny12/linking.html-->
-    
+
     <xsl:template match="svg:animation">
         <xsl:sequence select="f:fileset-entry(@xlink:href,'application/svg+xml',false())"/>
     </xsl:template>
-    
+
     <xsl:template match="svg:audio">
         <xsl:sequence select="f:fileset-entry(@xlink:href,@type,true())"/>
     </xsl:template>
-    
+
     <xsl:template match="svg:foreignObject[@xlink:href]">
         <xsl:sequence select="f:fileset-entry(@xlink:href,(),false())"/>
     </xsl:template>
-    
+
     <xsl:template match="svg:font-face-uri">
         <xsl:sequence select="f:fileset-entry(@xlink:href,(),false())"/>
     </xsl:template>
-    
+
     <xsl:template match="svg:handler[@xlink:href]">
         <xsl:sequence select="f:fileset-entry(@xlink:href,@type,false())"/>
     </xsl:template>
-    
+
     <xsl:template match="svg:image">
         <xsl:sequence select="f:fileset-entry(@xlink:href,@type,false())"/>
     </xsl:template>
-    
+
     <xsl:template match="svg:script[@xlink:href]">
         <xsl:sequence select="f:fileset-entry(@xlink:href,@type,false())"/>
     </xsl:template>
-    
+
     <xsl:template match="svg:video">
         <xsl:sequence select="f:fileset-entry(@xlink:href,@type,true())"/>
     </xsl:template>
-    
+
     <!--–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––>
      |  MathML                                                                     |
     <|–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––-->
-    
+
     <xsl:template match="m:annotation[@src]">
         <xsl:sequence select="f:fileset-entry(@src,@encoding,false())"/>
     </xsl:template>
-    
+
     <xsl:template match="m:math[@altimg]">
         <xsl:sequence select="f:fileset-entry(@altimg,(),false())"/>
     </xsl:template>
-    
+
     <xsl:template match="m:mglyph[@src]">
         <xsl:sequence select="f:fileset-entry(@src,(),false())"/>
     </xsl:template>
-    
+
     <!--–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––>
      |  Constructs a single fileset entry                                          |
     <|–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––-->
@@ -201,7 +203,7 @@
             </xsl:when>
             <xsl:when test="pf:is-absolute($href) and not($allow-remote)">
                 <xsl:message><![CDATA[[WARNING] remote resource ']]><xsl:value-of select="$href"
-                /><![CDATA[' should be made local.]]></xsl:message>
+                    /><![CDATA[' should be made local.]]></xsl:message>
             </xsl:when>
             <xsl:when test="$uri instance of attribute()">
                 <!--try to get the pre-computed original href from the parent element-->
@@ -228,8 +230,8 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:function>
-    
-    
+
+
     <!--–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––>
      |  Media Type Utils                                                           |
     <|–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––-->
@@ -249,8 +251,8 @@
             or pf:get-extension($uri)=('mp4','mpeg','m4v','mp4','flv','wmv','mov','ogv')"
         />
     </xsl:function>
-    
-    
+
+
     <!--–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––>
      |  Extract URLs from CSS                                                      |
     <|–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––-->
@@ -278,7 +280,7 @@
             </xsl:non-matching-substring>
         </xsl:analyze-string>
     </xsl:function>
-    
+
     <xsl:function name="f:parse-css-url" as="xs:string?">
         <xsl:param name="url" as="xs:string"/>
         <xsl:sequence
@@ -289,5 +291,5 @@
             else ()"
         />
     </xsl:function>
-    
+
 </xsl:stylesheet>

--- a/html-utils/src/test/xspec/catalog.xml
+++ b/html-utils/src/test/xspec/catalog.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri name="http://www.daisy.org/pipeline/modules/file-utils/xslt/uri-functions.xsl"
+        uri="mock-functions.xsl"/>
+</catalog>

--- a/html-utils/src/test/xspec/html-to-fileset.xspec
+++ b/html-utils/src/test/xspec/html-to-fileset.xspec
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns="http://www.w3.org/1999/xhtml" xmlns:d="http://www.daisy.org/ns/pipeline/data"
+    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    stylesheet="../../main/resources/xml/xslt/html-to-fileset.xsl">
+    
+    <x:variable name="doc-base" select="'file:/example/doc.html'"/>
+    
+    <!--TODO add more tests, for other HTML elements-->
+
+    <x:scenario label="The base URI">
+        <x:scenario label="of the HTML document">
+            <x:context>
+                <html/>
+            </x:context>
+            <x:expect label="is set to the fileset">
+                <d:fileset xml:base="file:/example/"/>
+            </x:expect>
+        </x:scenario>
+        
+    </x:scenario>
+    
+    <x:scenario label="'img' element">
+        <x:scenario label="with no @src">
+            <x:context>
+                <html>
+                    <img/>
+                </html>
+            </x:context>
+            <x:expect label="produces no fileset entry" test="empty(//d:file)"/>
+        </x:scenario>
+        <x:scenario label="with an empty @src">
+            <x:context>
+                <html>
+                    <img src=""/>
+                </html>
+            </x:context>
+            <x:expect label="produces no fileset entry" test="empty(//d:file)"/>
+        </x:scenario>
+        <x:scenario label="with a relative URI">
+            <x:context>
+                <html>
+                    <img src="my-image.png" xml:base="file:/my-base/"/>
+                </html>
+            </x:context>
+            <x:expect label="produces a fileset entry resolved to the attribute base" test="//d:file">
+                <d:file href="my-image.png" media-type="image/png" original-href="file:/my-base/my-image.png"/>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="with a relative URI and an original href">
+            <x:context>
+                <html>
+                    <img src="my-image.png" data-original-href="file:/other-base/other-uri.png" xml:base="file:/my-base/"/>
+                </html>
+            </x:context>
+            <x:expect label="produces a fileset entry and copies the original href" test="//d:file">
+                <d:file href="my-image.png" media-type="image/png" original-href="file:/other-base/other-uri.png"/>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="with an absolute file URI">
+            <x:context>
+                <html>
+                    <img src="file:/example/my-image.png"/>
+                </html>
+            </x:context>
+            <x:expect label="produces a fileset entry relativized to the fileset base" test="//d:file">
+                <d:file href="my-image.png" media-type="image/png" original-href="file:/example/my-image.png"/>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="with a 'data' URI">
+            <x:context>
+                <html>
+                    <img src="data:image/png;base64,ABCDEFG"/>
+                </html>
+            </x:context>
+            <x:expect label="produces no fileset entry" test="empty(//d:file)"/>
+        </x:scenario>
+        <x:scenario label="with an absolute remote URI">
+            <x:context>
+                <html>
+                    <img src="http:/www.example.org/my-image.png"/>
+                </html>
+            </x:context>
+            <x:expect label="produces no fileset entry" test="empty(//d:file)"/>
+        </x:scenario>
+    </x:scenario>
+
+</x:description>

--- a/html-utils/src/test/xspec/mock-functions.xsl
+++ b/html-utils/src/test/xspec/mock-functions.xsl
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:pf="http://www.daisy.org/ns/pipeline/functions" exclude-result-prefixes="#all"
+    version="2.0">
+
+    <xsl:function name="pf:get-extension" as="xs:string">
+        <xsl:param name="uri" as="xs:string?"/>
+        <xsl:sequence select="replace($uri,'^.*\.([^.]*)$','$1')"/>
+    </xsl:function>
+    
+    <xsl:function name="pf:get-scheme" as="xs:string">
+        <xsl:param name="uri" as="xs:string?"/>
+        <xsl:sequence select="replace($uri,'^(([^:]*):)?.+','$2')"/>
+    </xsl:function>
+    
+    <xsl:function name="pf:relativize-uri" as="xs:string">
+        <xsl:param name="uri" as="xs:string?"/>
+        <xsl:param name="base" as="xs:string?"/>
+        <xsl:variable name="base-dir" select="replace($base,'^(.+?/?)([^/]*)?$','$1')"/>
+        <xsl:sequence
+            select="if (starts-with($uri,$base-dir)) then substring($uri,string-length($base-dir)+1) else $uri"
+        />
+    </xsl:function>
+    
+    <xsl:function name="pf:is-absolute" as="xs:boolean">
+        <xsl:param name="uri" as="xs:string?"/>
+        <xsl:sequence select="matches($uri,'([^:]+:)?/.*')"/>
+    </xsl:function>
+    
+    <xsl:function name="pf:normalize-uri" as="xs:string">
+        <xsl:param name="uri" as="xs:string?"/>
+        <xsl:sequence select="$uri"/>
+    </xsl:function>
+    
+</xsl:stylesheet>


### PR DESCRIPTION
- Images with content encoded as a `data:` URI no longer show up
  in the fileset.
- Added XSpec tests
