### PR TITLE
[epub3-nav-utils] Include the full nav outline

### DIFF
--- a/epub3-nav-utils/src/main/resources/xml/xproc/epub3-nav-create-toc.xpl
+++ b/epub3-nav-utils/src/main/resources/xml/xproc/epub3-nav-create-toc.xpl
@@ -18,7 +18,7 @@
     <!-- integer -->
 
     <p:for-each name="tocs">
-        <p:output port="result"/>
+        <p:output port="result" sequence="true"/>
         <p:variable name="base-uri" select="p:base-uri(/*)"/>
         <p:variable name="base-ref"
             select="if (starts-with($base-uri,$base-dir)) 
@@ -33,10 +33,10 @@
                 <p:empty/>
             </p:input>
         </p:xslt>
-        <p:filter select="/h:ol/h:li[1]"/>
         <p:string-replace match="//@href">
             <p:with-option name="replace" select="concat('concat(&quot;',$base-ref,'&quot;,.)')"/>
         </p:string-replace>
+        <p:filter select="/h:ol/h:li"/>
     </p:for-each>
 
     <p:insert match="/h:nav/h:ol" position="first-child">


### PR DESCRIPTION
In `px:epub3-nav-create-toc`, only the first item of the HTML outline was included in the ToC. This is fine for some cases, but if the HTML outline has
several top-level entries (e.g. several `h1` elements), only the first outline
branch was included.

This is now fixed by this PR. Fixes [issue 352](https://code.google.com/p/daisy-pipeline/issues/detail?id=352)
