### PR TITLE
Improve EPUB metadata merge

### DIFF
--- a/epub3-pub-utils/src/main/resources/xml/xproc/create-metadata.merge.xsl
+++ b/epub3-pub-utils/src/main/resources/xml/xproc/create-metadata.merge.xsl
@@ -1,0 +1,343 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+    xmlns="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:f="http://www.daisy.org/ns/pipeline/internal-functions"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="f xs"
+    xpath-default-namespace="http://www.idpf.org/2007/opf">
+
+    <!--=========================================-->
+    <!-- Merges EPUB Publications Metadata
+        
+         Input: 
+           a set of 'metadata' element in the OPF
+           namespace, wrapped in a common root element
+           (the name of the wrapper is insignificant)
+           
+         Output:
+           a single 'metadata' element in the OPF
+           namespace, containing the 'merged' metadata.
+    -->
+    <!--TODO: document merge rules. For now, see the tests.-->
+    <!--=========================================-->
+
+    <xsl:output indent="yes"/>
+
+    <xsl:key name="refines" match="//meta[@refines]" use="f:unified-id(@refines)"/>
+
+    <xsl:template match="/*">
+        <metadata>
+            <xsl:variable name="unified-prefix-decl" as="element()*"
+                select="f:unified-prefix-decl(/)"/>
+            <xsl:if test="exists($unified-prefix-decl)">
+                <xsl:attribute name="prefix"
+                    select="for $vocab in $unified-prefix-decl return concat($vocab/@prefix,': ',$vocab/@uri)"
+                />
+            </xsl:if>
+
+            <!-- dc:title(s) and refines -->
+            <xsl:variable name="title" select="(//metadata/dc:title[not(@refines)])[1]"/>
+            <xsl:apply-templates select="$title"/>
+            <xsl:apply-templates
+                select="$title/ancestor::metadata/dc:title[not(@refines) and (. != $title)]"/>
+
+            <!-- dc:identifier(s) and refines -->
+            <xsl:variable name="identifier" select="(//metadata/dc:identifier[not(@refines)])[1]"/>
+            <xsl:apply-templates select="$identifier"/>
+            <xsl:apply-templates
+                select="$identifier/ancestor::metadata/dc:identifier[not(@refines) and (. != $identifier)]"/>
+
+            <!-- dc:language(s) and refines -->
+            <xsl:variable name="language" select="(//metadata/dc:language[not(@refines)])[1]"/>
+            <xsl:apply-templates select="$language"/>
+            <xsl:apply-templates
+                select="$language/ancestor::metadata/dc:language[not(@refines) and (. != $language)]"/>
+
+            <!--generate dc:modified-->
+            <meta property="dcterms:modified">
+                <xsl:value-of
+                    select="format-dateTime(
+                    adjust-dateTime-to-timezone(current-dateTime(),xs:dayTimeDuration('PT0H')),
+                    '[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01]Z')"
+                />
+            </meta>
+
+            <!--DCMES Optional Elements [0 or more]
+               * NOTE: several dc:type are allowed in EPUB 3.01 
+               * only one: date | source
+            -->
+            <xsl:for-each-group
+                select="//(dc:contributor|dc:coverage|dc:creator|dc:date|dc:description|dc:format
+                          |dc:publisher|dc:relation|dc:rights|dc:source|dc:subject|dc:type)[empty(@refines)]"
+                group-by="name()">
+                <xsl:choose>
+                    <xsl:when test="self::dc:date|self::dc:source">
+                        <xsl:apply-templates select="current()"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:apply-templates
+                            select="current-group()[ancestor::metadata is current()/ancestor::metadata]"
+                        />
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:for-each-group>
+
+            <!--meta [0 or more]-->
+            <xsl:for-each-group select="//meta[empty(@refines)]"
+                group-by="f:expand-property(@property)/@uri">
+                <xsl:if test="current-grouping-key()">
+                    <xsl:apply-templates
+                        select="current-group()[ancestor::metadata is current()/ancestor::metadata]"
+                    />
+                </xsl:if>
+            </xsl:for-each-group>
+
+            <xsl:apply-templates select="//link"/>
+        </metadata>
+    </xsl:template>
+
+    <xsl:template match="dc:identifier">
+        <dc:identifier id="{f:unique-id((@id,generate-id())[1],//@id except @id)}">
+            <xsl:apply-templates select="node() | @* except @id"/>
+        </dc:identifier>
+        <xsl:apply-templates select="key('refines',f:unified-id(@id))"/>
+    </xsl:template>
+
+    <xsl:template match="dc:*">
+        <xsl:next-match/>
+        <xsl:apply-templates select="key('refines',f:unified-id(@id))"/>
+    </xsl:template>
+
+    <xsl:template match="meta">
+        <xsl:variable name="property" select="f:expand-property(@property)"/>
+        <xsl:choose>
+            <xsl:when test="$property/@uri='http://purl.org/dc/terms/modified'"/>
+            <xsl:when test="not(normalize-space())">
+                <xsl:message>[WARNING] Discarding empty property '<xsl:value-of select="@property"
+                    />'.</xsl:message>
+            </xsl:when>
+            <xsl:when test="$property/@uri=''">
+                <xsl:message>[WARNING] Discarding property '<xsl:value-of select="@property"/>' from
+                    an undeclared vocab.</xsl:message>
+            </xsl:when>
+            <xsl:when
+                test="$property/@prefix='' and not($property/@name=('alternate-script','display-seq',
+                'file-as','group-position','identifier-type','meta-auth','role','title-type'))">
+                <xsl:message>[WARNING] Discarding unknown property '<xsl:value-of select="@property"
+                    />'.</xsl:message>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:next-match/>
+            </xsl:otherwise>
+        </xsl:choose>
+        <xsl:apply-templates select="key('refines',f:unified-id(@id))"/>
+    </xsl:template>
+
+    <xsl:template match="link">
+        <xsl:variable name="rel" select="f:expand-property(@rel)"/>
+        <xsl:choose>
+            <xsl:when test="not(@href) or not(@rel)">
+                <xsl:message>[WARNING] Discarding link with no @href or @rel
+                    attributes.</xsl:message>
+            </xsl:when>
+            <xsl:when
+                test="$rel/@prefix='' and not($rel/@name=('marc21xml-record',
+                'mods-record','onix-record','xml-signature xmp-record'))">
+                <xsl:message>[WARNING] Discarding link with unknown @rel value '<xsl:value-of
+                        select="@rel"/>'.</xsl:message>
+            </xsl:when>
+            <xsl:when test="$rel/@uri=''">
+                <xsl:message>[WARNING] Discarding link with @rel value '<xsl:value-of
+                        select="@property"/>' from an undeclared vocab.</xsl:message>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:next-match/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="@property">
+        <xsl:attribute name="property" select="f:expand-property(.)/@name"/>
+    </xsl:template>
+    <xsl:template match="@scheme">
+        <xsl:attribute name="scheme" select="f:expand-property(.)/@name"/>
+    </xsl:template>
+    <xsl:template match="@id">
+        <xsl:attribute name="id" select="f:unified-id(.)"/>
+    </xsl:template>
+    <xsl:template match="@refines">
+        <xsl:attribute name="refines" select="concat('#',f:unified-id(.))"/>
+    </xsl:template>
+
+
+    <xsl:template match="node() | @*">
+        <xsl:copy>
+            <xsl:apply-templates select="node() | @*"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- 
+        Returns a non-conflicting ID for an *existing* ID or IDREF attribute
+        The non-conflicting ID is created by appending the position number
+        of the parent metadata set for all sets after the first
+    -->
+    <xsl:function name="f:unified-id" as="xs:string">
+        <xsl:param name="id" as="attribute()?"/>
+        <xsl:variable name="count" select="count($id/ancestor::metadata/preceding-sibling::*)"
+            as="xs:integer"/>
+        <xsl:sequence
+            select="concat(if (starts-with($id,'#')) then substring($id,2) else $id, if ($count) then $count+1 else '')"
+        />
+    </xsl:function>
+
+    
+    <!-- 
+        Returns a non-conflicting ID for a *new* ID or IDREF attribute, given
+        a sequence of existing IDs.
+        The non-conflicting ID is created by prepending a number of 'x'
+        to the ID until it doesn't conflict with existing ones.
+        This rule guarantees it won't conflict with IDs created by f:unified-id().
+    -->
+    <xsl:function name="f:unique-id" as="xs:string">
+        <xsl:param name="id" as="xs:string" required="yes"/>
+        <xsl:param name="existing" as="xs:string*" required="yes"/>
+        <xsl:sequence
+            select="
+            if (not($id=$existing)) then $id
+            else f:unique-id(concat('x',$id),$existing)
+            "
+        />
+    </xsl:function>
+
+    <!--
+        Returns a sequence of `f:property` elements from a property-typeed attribute where:
+        
+         * @prefix contains the resolved, unified prefix for the property
+         * @uri contains the resolved absolute URI of the property
+         * @name contains the resolved name for the property, prefixed by the unified prefix
+    -->
+    <!--TODO move to a generic util ?-->
+    <xsl:function name="f:expand-property" as="element(f:property)">
+        <xsl:param name="property" as="attribute()?"/>
+        <!--TODO move to a global variable when XSpec supports it-->
+        <xsl:variable name="all-prefix-decl" as="element()*"
+            select="f:all-prefix-decl($property/ancestor::node()[. instance of document-node()])"/>
+        <xsl:variable name="unified-prefix-decl" as="element()*"
+            select="f:unified-prefix-decl($property/ancestor::node()[. instance of document-node()])"/>
+        <xsl:variable name="prefix" select="substring-before($property,':')" as="xs:string"/>
+        <xsl:variable name="reference" select="replace($property,'(.+:)','')" as="xs:string"/>
+        <xsl:variable name="vocab"
+            select="
+            ($all-prefix-decl[@id=generate-id($property/ancestor::metadata)]/f:vocab[@prefix=$prefix]/@uri,
+            if ($prefix='') then 'http://idpf.org/epub/vocab/package/#'
+            else if ($prefix='dcterms') then 'http://purl.org/dc/terms/'
+            else if ($prefix='marc') then 'http://id.loc.gov/vocabulary/'
+            else if ($prefix='media') then 'http://www.idpf.org/epub/vocab/overlays/#'
+            else if ($prefix='onix') then 'http://www.editeur.org/ONIX/book/codelists/current.html#'
+            else if ($prefix='xsd') then 'http://www.w3.org/2001/XMLSchema#'
+            else '')[1]
+            "
+            as="xs:string"/>
+        <xsl:variable name="unified-prefix"
+            select="
+            if ($vocab='http://idpf.org/epub/vocab/package/#') then '' 
+            else if ($vocab='http://purl.org/dc/terms/') then 'dcterms' 
+            else if ($vocab='http://id.loc.gov/vocabulary/') then 'marc'
+            else if ($vocab='http://www.idpf.org/epub/vocab/overlays/#') then 'media'
+            else if ($vocab='http://www.editeur.org/ONIX/book/codelists/current.html#') then 'onix'
+            else if ($vocab='http://www.w3.org/2001/XMLSchema#') then 'xsd'
+            else $unified-prefix-decl[@uri=$vocab]/@prefix"
+            as="xs:string?"/>
+        <f:property prefix="{$unified-prefix}"
+            uri="{if($vocab) then concat($vocab,$reference) else ''}"
+            name="{if ($unified-prefix) then concat($unified-prefix,':',$reference)  else $reference}"
+        />
+    </xsl:function>
+
+    <!--
+        Returns a sequence of `f:vocab` elements representing vocab declarations
+        in a `@prefix` attribute where:
+        
+         * @prefix contains the declared prefix
+         * @uri contains the vocab URI
+    -->
+    <xsl:function name="f:parse-prefix-decl" as="element(f:vocab)*">
+        <xsl:param name="prefix-declaration" as="xs:string?"/>
+        <xsl:for-each-group select="tokenize($prefix-declaration,'\s+')"
+            group-adjacent="(position()+1) idiv 2">
+            <f:vocab prefix="{substring-before(current-group()[1],':')}" uri="{current-group()[2]}"
+            />
+        </xsl:for-each-group>
+    </xsl:function>
+
+
+    <!--
+        Returns all the vocabs declared in the various metadata sets, as `f:vocab` elements
+        grouped by `metadata` elements (these latter having `@id` attributes generated by
+        `generate-id()`. 
+        
+        Vocabs that are not used in `@property`, `@scheme` or `@rel` are discarded.
+    -->
+    <xsl:function name="f:all-prefix-decl" as="element()*">
+        <xsl:param name="doc" as="document-node()?"/>
+        <xsl:for-each select="$doc//metadata">
+            <metadata id="{generate-id(.)}">
+                <xsl:sequence
+                    select="f:parse-prefix-decl(@prefix)
+                    [some $prop in $doc//meta/(@property|@scheme)|$doc//link/@rel
+                     satisfies starts-with($prop,concat(@prefix,':'))]"
+                />
+            </metadata>
+        </xsl:for-each>
+    </xsl:function>
+
+    <!--
+        Returns a sequence of `f:vocab` elements representing unified vocab declarations
+    throughout the document passed as argument.
+        
+        * reserved vocabs are discarded (don't have to be declared)
+        * @prefix are unified, if it is overriding a reserved prefix, a new prefix is defined
+        
+    -->
+    <xsl:function name="f:unified-prefix-decl" as="element()*">
+        <xsl:param name="doc" as="document-node()"/>
+        <xsl:variable name="all-decl" select="f:all-prefix-decl($doc)//f:vocab"
+            as="element(f:vocab)*"/>
+        <xsl:for-each-group select="$all-decl" group-by="@uri">
+            <xsl:if
+                test="not(current-grouping-key()=
+                ('http://idpf.org/epub/vocab/package/#',
+                'http://purl.org/dc/terms/',
+                'http://id.loc.gov/vocabulary/',
+                'http://www.idpf.org/epub/vocab/overlays/#',
+                'http://www.editeur.org/ONIX/book/codelists/current.html#',
+                'http://www.w3.org/2001/XMLSchema#'))">
+                <xsl:choose>
+                    <xsl:when test="@prefix=('dcterms','marc','media','onix','xsd')">
+                        <f:vocab
+                            prefix="{f:unique-prefix(concat(@prefix,position()+1),$all-decl/@prefix)}"
+                            uri="{@uri}"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:copy-of select="current()"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:if>
+        </xsl:for-each-group>
+    </xsl:function>
+
+    <!--
+        Returns a unique prefix from a given prefix and a sequence of existing prefixes.
+        The unique prefix is generated by appending the needed amount of '_'.
+    -->
+    <xsl:function name="f:unique-prefix" as="xs:string">
+        <xsl:param name="prefix" as="xs:string" required="yes"/>
+        <xsl:param name="existing" as="xs:string*" required="yes"/>
+        <xsl:sequence
+            select="
+            if (not($prefix=$existing)) then $prefix
+            else f:unique-prefix(concat($prefix,'_'),$existing)
+            "
+        />
+    </xsl:function>
+
+</xsl:stylesheet>

--- a/epub3-pub-utils/src/main/resources/xml/xproc/create-package-doc.xpl
+++ b/epub3-pub-utils/src/main/resources/xml/xproc/create-package-doc.xpl
@@ -10,7 +10,11 @@
             <d:fileset/>
         </p:inline>
     </p:input>
-    <p:input port="metadata"/>
+    <p:input port="metadata" sequence="true">
+        <p:inline>
+            <opf:metadata/>
+        </p:inline>
+    </p:input>
     <p:input port="bindings" sequence="true">
         <p:empty/>
     </p:input>
@@ -72,53 +76,28 @@
 
     <p:group name="metadata">
         <p:output port="result"/>
-        <p:identity>
+        <p:uuid name="default-metadata" match="dc:identifier/text()">
+            <p:input port="source">
+                <p:inline>
+                    <opf:metadata>
+                        <dc:title>Unknown</dc:title>
+                        <dc:identifier>generated-uuid</dc:identifier>
+                    </opf:metadata>
+                </p:inline>
+            </p:input>
+        </p:uuid>
+        <p:wrap-sequence wrapper="wrapper">
             <p:input port="source">
                 <p:pipe port="metadata" step="main"/>
+                <p:pipe port="result" step="default-metadata"/>
             </p:input>
-        </p:identity>
-        <p:choose>
-            <p:when test="empty(/opf:metadata/dc:identifier)">
-                <p:insert match="opf:metadata" position="first-child">
-                    <p:input port="insertion">
-                        <p:inline exclude-inline-prefixes="#all">
-                            <dc:identifier id="pub-id">@@</dc:identifier>
-                        </p:inline>
-                        <p:inline xmlns="http://www.idpf.org/2007/opf" exclude-inline-prefixes="#all">
-                            <meta refines="#pub-id" property="identifier-type" scheme="xsd:string">uuid</meta>
-                        </p:inline>
-                    </p:input>
-                </p:insert>
-                <p:uuid match="dc:identifier/text()"/>
-            </p:when>
-            <p:otherwise>
-                <p:identity/>
-            </p:otherwise>
-        </p:choose>
-        <p:choose>
-            <p:when test="/opf:metadata/dc:identifier/@id">
-                <p:identity/>
-            </p:when>
-            <p:when test="//@id='pub-id'">
-                <p:xslt>
-                    <p:input port="parameters">
-                        <p:empty/>
-                    </p:input>
-                    <p:input port="stylesheet">
-                        <p:document href="create-package-doc.generate-identifier.xsl"/>
-                    </p:input>
-                </p:xslt>
-            </p:when>
-            <p:otherwise>
-                <p:add-attribute match="/opf:metadata/dc:identifier" attribute-name="id" attribute-value="pub-id"/>
-            </p:otherwise>
-        </p:choose>
+        </p:wrap-sequence>
         <p:xslt>
+            <p:input port="stylesheet">
+                <p:document href="create-package-doc.merge-metadata.xsl"/>
+            </p:input>
             <p:input port="parameters">
                 <p:empty/>
-            </p:input>
-            <p:input port="stylesheet">
-                <p:document href="create-package-doc.generate-dcterms-modified.xsl"/>
             </p:input>
         </p:xslt>
         <p:delete match="opf:meta[@property='media:duration']"/>

--- a/epub3-pub-utils/src/test/xspec/create-metadata.merge.xspec
+++ b/epub3-pub-utils/src/test/xspec/create-metadata.merge.xspec
@@ -1,0 +1,737 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" xmlns="http://www.idpf.org/2007/opf"
+    xmlns:opf="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:f="http://www.daisy.org/ns/pipeline/internal-functions"
+    stylesheet="../../main/resources/xml/xproc/create-metadata.merge.xsl">
+
+    <x:scenario label="IDs :: ">
+        <x:scenario label="conflicting IDs">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <meta id="id" property="dcterms:creator">foo</meta>
+                    </metadata>
+                    <metadata>
+                        <meta id="id" property="dcterms:publisher">bar</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="should be resolved"
+                test="count(//*[.=('foo','bar')])=2  and (//*[.='foo']/@id ne //*[.='bar']/@id)"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Titles ::">
+        <x:scenario label="when there is only one 'dc:title'">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:title>foo</dc:title>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is copied" test="//dc:title">
+                <dc:title>foo</dc:title>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="when there are multiple 'dc:title' in the same set">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:title>foo</dc:title>
+                        <dc:title>bar</dc:title>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="all are copied" test="//dc:title">
+                <dc:title>foo</dc:title>
+                <dc:title>bar</dc:title>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="when there are 'dc:title' in multiple sets">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:title>foo</dc:title>
+                    </metadata>
+                    <metadata>
+                        <dc:title>bar</dc:title>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the first one is copied" test="//dc:title">
+                <dc:title>foo</dc:title>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="when there is a 'dc:title' in a non-opf metadata namespace">
+            <x:context>
+                <wrapper>
+                    <metadata xmlns="">
+                        <dc:title>bar</dc:title>
+                    </metadata>
+                    <metadata>
+                        <dc:title>foo</dc:title>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is ignored" test="//dc:title">
+                <dc:title>foo</dc:title>
+            </x:expect>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Refines ::">
+        <!--TODO test metadata refining resource-->
+        <x:scenario label="when metadata refines a dc:title element">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:title id="t2">title</dc:title>
+                        <meta refines="#t2" property="title-type">refine1</meta>
+                        <meta refines="#t2" property="group-position">refine2</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is copied"
+                test="count(//dc:title[.='title']|//opf:meta[.=('refine1','refine2')])=3"/>
+            <x:expect label="refines attributes are correct"
+                test="every $refine in //@refines satisfies $refine = concat('#',//dc:title/@id)"/>
+        </x:scenario>
+        <x:scenario label="when metadata refines a dc:language element">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:language id="id">en</dc:language>
+                        <meta refines="#id" property="role">refine</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is copied" test="exists(//opf:meta[.=('refine')])"/>
+            <x:expect label="refines attributes are correct"
+                test="every $refine in //@refines satisfies $refine = concat('#',//dc:language/@id)"
+            />
+        </x:scenario>
+        <x:scenario label="when metadata refines a dc:identifier element">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:identifier id="id">id</dc:identifier>
+                        <meta refines="#id" property="role">refine</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is copied" test="exists(//opf:meta[.=('refine')])"/>
+            <x:expect label="refines attributes are correct"
+                test="every $refine in //@refines satisfies $refine = concat('#',//dc:identifier/@id)"
+            />
+        </x:scenario>
+        <x:scenario label="when metadata refines a DCMES element">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:creator id="id">creator</dc:creator>
+                        <meta refines="#id" property="role">refine</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is copied" test="exists(//opf:meta[.=('refine')])"/>
+            <x:expect label="refines attributes are correct"
+                test="every $refine in //@refines satisfies $refine = concat('#',//dc:creator/@id)"
+            />
+        </x:scenario>
+        <x:scenario label="when metadata refines a meta element">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <meta property="dcterms:creator" id="id">creator</meta>
+                        <meta refines="#id" property="role">refine</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is copied" test="exists(//opf:meta[.=('refine')])"/>
+            <x:expect label="refines attributes are correct"
+                test="every $refine in //@refines satisfies $refine = concat('#',//opf:meta[@property='dcterms:creator']/@id)"
+            />
+        </x:scenario>
+        <x:scenario label="when metadata refines an unexisting expression">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <meta refines="#t1" property="group-position">1</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is ignored" test="empty(//dc:title|//opf:meta[@refines])"/>
+        </x:scenario>
+        <x:scenario label="transitive refines">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:title id="t2">title</dc:title>
+                        <meta id="r" refines="#t2" property="title-type">refine1</meta>
+                        <meta refines="#r" property="group-position">refine2</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is copied"
+                test="count(//dc:title[.='title']|//opf:meta[.=('refine1','refine2')])=3"/>
+            <x:expect label="refines attributes are correct"
+                test="//@refines=concat('#',//dc:title/@id) and //@refines=//@refines/concat('#',../@id)"
+            />
+        </x:scenario>
+        <x:scenario label="when metadata refines an expression with the same ID in another set">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:title id="t2">title</dc:title>
+                        <meta refines="#t2" property="title-type">refine1</meta>
+                    </metadata>
+                    <metadata>
+                        <dc:title id="t2">other</dc:title>
+                        <meta refines="#t2" property="title-type">refine2</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is ignored" test="count(//opf:meta[.=('refine1','refine2')])=1"/>
+        </x:scenario>
+        <x:scenario label="when metadata refines an expression with a conflicting ID">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <meta id="id" property="dcterms:creator">foo</meta>
+                    </metadata>
+                    <metadata>
+                        <meta id="id" property="dcterms:publisher">bar</meta>
+                        <meta refines="#id" property="role">refines-bar</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the refine IDREF is changed"
+                test="concat('#',//opf:meta[.='bar']/@id)=//opf:meta[.='refines-bar']/@refines"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Identifier ::">
+        <x:scenario label="when there is only one 'dc:identifier'">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:identifier>foo</dc:identifier>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is copied" test="exists(//dc:identifier[.='foo'])"/>
+            <x:expect label="it is given an ID"
+                test="normalize-space(//dc:identifier[.='foo']/@id) ne ''"/>
+        </x:scenario>
+        <x:scenario label="when there are multiple 'dc:identifier' in the same set">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:identifier>foo</dc:identifier>
+                        <dc:identifier>bar</dc:identifier>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="all are copied" test="count(//dc:identifier[.=('foo','bar')])=2"/>
+        </x:scenario>
+        <x:scenario label="when there are 'dc:identifier' in multiple sets">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:identifier>foo</dc:identifier>
+                    </metadata>
+                    <metadata>
+                        <dc:identifier>bar</dc:identifier>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the first one is copied"
+                test="exists(//dc:identifier[.='foo'])
+                and empty(//dc:identifier[.='bar'])"
+            />
+        </x:scenario>
+        <x:scenario label="when a 'dc:identifier' has an ID">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:identifier id="foo">foo</dc:identifier>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is copied" test="//dc:identifier[.='foo']/@id='foo'"/>
+        </x:scenario>
+        <x:scenario label="when an 'dc:identifier' ID must be generated">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:identifier>foo</dc:identifier>
+                        <dc:identifier id="d18e3">bar</dc:identifier>
+                        <dc:identifier id="xd18e3">baz</dc:identifier>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is non conflicting"
+                test="count(distinct-values(//dc:identifier/@id))=3"/>
+        </x:scenario>
+
+    </x:scenario>
+
+    <x:scenario label="Language ::">
+        <x:scenario label="when there is only one 'dc:language'">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:language>en</dc:language>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is copied" test="//dc:language">
+                <dc:language>en</dc:language>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="when there are multiple 'dc:language' in the same set">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:language>en</dc:language>
+                        <dc:language>fr</dc:language>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="all are copied" test="//dc:language">
+                <dc:language>en</dc:language>
+                <dc:language>fr</dc:language>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="when there are 'dc:language' in multiple sets">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:language>en</dc:language>
+                    </metadata>
+                    <metadata>
+                        <dc:language>fr</dc:language>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the first one is copied" test="//dc:language">
+                <dc:language>en</dc:language>
+            </x:expect>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Modification Date ::">
+        <x:scenario label="when there is no 'dcterms:modified'">
+            <x:context>
+                <wrapper>
+                    <metadata> </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is generated"
+                test="exists(//opf:meta[@property='dcterms:modified'])"/>
+            <x:expect label="with a valid date"
+                test="//opf:meta[@property='dcterms:modified']/matches(.,'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z')"
+            />
+        </x:scenario>
+        <x:scenario label="when there are existing 'dcterms:modified'">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <meta property="dcterms:modified">2011-01-01T12:00:00Z</meta>
+                    </metadata>
+                    <metadata>
+                        <meta property="dcterms:modified">2012-01-01T12:00:00Z</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="only one is copied, and is overriden"
+                test="count(//opf:meta[@property='dcterms:modified'])=1 
+                and normalize-space(//opf:meta[@property='dcterms:modified']) ne '2011-01-01T12:00:00Z'"
+            />
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="DCMES Elements ::">
+        <x:scenario label="valid DCMES elements">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:contributor>foo</dc:contributor>
+                        <dc:coverage>foo</dc:coverage>
+                        <dc:creator>foo</dc:creator>
+                        <dc:date>2000-01-01T00:00:00Z</dc:date>
+                        <dc:description>foo</dc:description>
+                        <dc:format>foo</dc:format>
+                        <dc:publisher>foo</dc:publisher>
+                        <dc:relation>foo</dc:relation>
+                        <dc:rights>foo</dc:rights>
+                        <dc:source>foo</dc:source>
+                        <dc:subject>foo</dc:subject>
+                        <dc:type>foo</dc:type>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="are copied" test="//dc:*">
+                <dc:contributor>foo</dc:contributor>
+                <dc:coverage>foo</dc:coverage>
+                <dc:creator>foo</dc:creator>
+                <dc:date>2000-01-01T00:00:00Z</dc:date>
+                <dc:description>foo</dc:description>
+                <dc:format>foo</dc:format>
+                <dc:publisher>foo</dc:publisher>
+                <dc:relation>foo</dc:relation>
+                <dc:rights>foo</dc:rights>
+                <dc:source>foo</dc:source>
+                <dc:subject>foo</dc:subject>
+                <dc:type>foo</dc:type>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="when elements are distributed in multiple sets">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:contributor>foo</dc:contributor>
+                        <dc:contributor>bar</dc:contributor>
+                    </metadata>
+                    <metadata>
+                        <dc:contributor>baz</dc:contributor>
+                        <dc:creator>foo</dc:creator>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="elements are copied from the first set they belong to" test="//dc:*">
+                <dc:contributor>foo</dc:contributor>
+                <dc:contributor>bar</dc:contributor>
+                <dc:creator>foo</dc:creator>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="when elements are allowed only once">
+            <!--Note: EPUB 3.01 allows several 'dc:type' elements-->
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <dc:date>2000-01-01T00:00:00Z</dc:date>
+                        <dc:date>2000-02-01T00:00:00Z</dc:date>
+                        <dc:source>foo</dc:source>
+                        <dc:source>bar</dc:source>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="only the first occurence is copied" test="//dc:*">
+                <dc:date>2000-01-01T00:00:00Z</dc:date>
+                <dc:source>foo</dc:source>
+            </x:expect>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Meta Elements ::">
+        <x:scenario label="meta elements">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <meta property="dcterms:creator">foo</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label=" are copied by default"
+                test="//opf:meta[@property = 'dcterms:creator']">
+                <meta property="dcterms:creator">foo</meta>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="meta elements with a property in the default vocab">
+            <!--Note: all properties from the default vocab current *should* refine other props, but this could be changed in the future-->
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <meta property="role">foo</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label=" are copied by default" test="//opf:meta[@property = 'role']">
+                <meta property="role">foo</meta>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="when there are multiple expressions of the same property in the same set">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <meta property="dcterms:creator">foo</meta>
+                        <meta property="dcterms:creator">bar</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="they are all copied" test="//opf:meta[@property = 'dcterms:creator']">
+                <meta property="dcterms:creator">foo</meta>
+                <meta property="dcterms:creator">bar</meta>
+            </x:expect>
+        </x:scenario>
+        <x:scenario
+            label="when there are multiple expressions of the same property in multiple sets">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <meta property="dcterms:creator">foo</meta>
+                    </metadata>
+                    <metadata>
+                        <meta property="dcterms:creator">bar</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the ones from the first set are copied"
+                test="//opf:meta[@property = 'dcterms:creator']">
+                <meta property="dcterms:creator">foo</meta>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="when there is a 'scheme' attribute">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <meta property="role" scheme="marc:relators">aut</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is preserved" test="//opf:meta[@property='role']">
+                <meta property="role" scheme="marc:relators">aut</meta>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="when an expression is empty">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <meta property="dcterms:creator"/>
+                        <meta property="dcterms:creator"> </meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is discarded" test="empty(//opf:meta[@property='dcterms:creator'])"
+            />
+        </x:scenario>
+        <x:scenario label="when a property from the default vocab is invalid">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <meta property="foo">bar</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is discarded" test="empty(//opf:meta[.='bar'])"/>
+        </x:scenario>
+        <x:scenario label="when no vocab is declared for the property's prefix">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <meta property="foo:foo">bar</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="it is discarded" test="empty(//opf:meta[.='bar'])"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Prefixes ::">
+        <x:scenario label="when a property uses a non-default prefix">
+            <x:context>
+                <wrapper>
+                    <metadata prefix="foo: http://example.org/foo">
+                        <meta property="foo:foo">foo</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the prefix declaration is preserved"
+                test="//opf:metadata/@prefix = 'foo: http://example.org/foo'"/>
+        </x:scenario>
+        <x:scenario label="when two sets use different prefixes for the same vocab">
+            <x:context>
+                <wrapper>
+                    <metadata prefix="foo: http://example.org/foo">
+                        <meta property="foo:foo">foo</meta>
+                    </metadata>
+                    <metadata prefix="fooz: http://example.org/foo">
+                        <meta property="fooz:fooz">fooz</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the prefix declarations are unified"
+                test="//opf:metadata/@prefix = 'foo: http://example.org/foo'"/>
+            <x:expect label="the prefix is renamed where needed"
+                test="//opf:meta/@property = 'foo:fooz'"/>
+        </x:scenario>
+        <x:scenario label="when two properties from two sets use non-default prefixes">
+            <x:context>
+                <wrapper>
+                    <metadata prefix="foo: http://example.org/foo">
+                        <meta property="foo:foo">foo</meta>
+                    </metadata>
+                    <metadata prefix="bar: http://example.org/bar">
+                        <meta property="bar:bar">bar</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the prefix declarations are merged"
+                test="//opf:metadata/@prefix = 'foo: http://example.org/foo bar: http://example.org/bar'"
+            />
+        </x:scenario>
+        <x:scenario label="when a set re-declares a reserved prefix">
+            <x:context>
+                <wrapper>
+                    <metadata
+                        prefix="dcterms: http://purl.org/dc/terms/
+                                    foo: http://example.org/foo
+                                   marc: http://id.loc.gov/vocabulary/
+                                  media: http://www.idpf.org/epub/vocab/overlays/#
+                                   onix: http://www.editeur.org/ONIX/book/codelists/current.html#
+                                    xsd: http://www.w3.org/2001/XMLSchema#">
+                        <meta property="marc:foo">foo</meta>
+                        <meta property="foo:foo">foo</meta>
+                        <meta property="media:foo">foo</meta>
+                        <meta property="onix:foo">foo</meta>
+                        <meta property="xsd:foo">foo</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the reserved prefix declarations are discarded"
+                test="//opf:metadata/@prefix = 'foo: http://example.org/foo'"/>
+        </x:scenario>
+        <x:scenario label="when a set declares a custom prefix for a reserved vocab">
+            <x:context>
+                <wrapper>
+                    <metadata prefix="foo: http://purl.org/dc/terms/">
+                        <meta property="foo:subject">foo</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the prefix declaration is removed" test="empty(//opf:metadata/@prefix)"/>
+            <x:expect label="the prefix is set to the reserved prefix"
+                test="//opf:meta[.='foo']/@property = 'dcterms:subject'"/>
+        </x:scenario>
+        <x:scenario label="when a set uses a reserved prefix for a custom vocab">
+            <x:context>
+                <wrapper>
+                    <metadata prefix="dcterms: http://example.org/terms/">
+                        <meta property="dcterms:subject">foo</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the prefix declaration is kept"
+                test="tokenize(//opf:metadata/@prefix,'\s+')='http://example.org/terms/'"/>
+            <x:expect label="the prefix is changed to an unreserved prefix"
+                test="not(tokenize(//opf:meta[.='foo']/@property,':')[1] = 'dcterms')"/>
+        </x:scenario>
+        <x:scenario label="when different sets uses a reserved prefix for different custom vocabs">
+            <x:context>
+                <wrapper>
+                    <metadata prefix="dcterms: http://example.org/terms/">
+                        <meta property="dcterms:subject">foo</meta>
+                    </metadata>
+                    <metadata prefix="dcterms: http://example.com/terms/">
+                        <meta property="dcterms:subject">bar</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the prefix declarations are kept"
+                test="contains(//opf:metadata/@prefix,
+                concat(tokenize(//opf:meta[.='foo']/@property,':')[1],': http://example.org/terms/'))
+                and
+                contains(//opf:metadata/@prefix,
+                concat(tokenize(//opf:meta[.='bar']/@property,':')[1],': http://example.com/terms/'))"/>
+            <x:expect label="the prefixes are changed to unreserved prefixes"
+                test="not(contains(//opf:metadata/@prefix,'dcterms:'))"/>
+        </x:scenario>
+        <x:scenario label="when a set declares an unused prefix">
+            <x:context>
+                <wrapper>
+                    <metadata prefix="foo: http://example.org/foo bar: http://example.org/bar">
+                        <meta property="foo:foo">foo</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the unused prefix declaration is discarded"
+                test="//opf:metadata/@prefix = 'foo: http://example.org/foo'"/>
+        </x:scenario>
+        <x:scenario label="when none of the declared prefixes are used">
+            <x:context>
+                <wrapper>
+                    <metadata prefix="foo: http://example.org/foo"> </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the prefix declaration is discarded"
+                test="empty(//opf:metadata/@prefix)"/>
+        </x:scenario>
+        <x:scenario label="when there is a 'scheme' attribute in a non-default prefix">
+            <x:context>
+                <wrapper>
+                    <metadata prefix="foo: http://example.org/foo">
+                        <meta property="dcterms:creator" scheme="foo:bar">foo</meta>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the prefix declaration is preserved"
+                test="//opf:metadata/@prefix = 'foo: http://example.org/foo'"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Links ::">
+        <x:scenario label="valid link elements">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <link rel="onix-record" href="http://example.org/onix/12389347"/>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="are copied as-is" test="//opf:link">
+                <link rel="onix-record" href="http://example.org/onix/12389347"/>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="when @href or @rel is missing">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <link href="http://example.org/onix/12389347"/>
+                        <link rel="onix-record"/>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the link elements are discarded" test="empty(//opf:link)"/>
+        </x:scenario>
+        <x:scenario label="when @rel is not in the default vocab and doesn't have a valid prefix">
+            <x:context>
+                <wrapper>
+                    <metadata>
+                        <link rel="foo" href="http://example.org/foo"/>
+                        <link rel="foo:foo" href="http://example.org/foo"/>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the link elements are discarded" test="empty(//opf:link)"/>
+        </x:scenario>
+        <x:scenario label="when @rel uses a custom prefix">
+            <x:context>
+                <wrapper>
+                    <metadata prefix="foo: http://example.org/foo">
+                        <link rel="foo:foo" href="http://example.org/foo"/>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="the prefix declaration is preserved"
+                test="//opf:metadata/@prefix = 'foo: http://example.org/foo'"/>
+        </x:scenario>
+        <x:scenario label="when @rel uses a custom prefix and other prefixes are also declared">
+            <x:context>
+                <wrapper>
+                    <metadata prefix="foo: http://example.org/foo">
+                        <meta property="foo:foo">foo</meta>
+                    </metadata>
+                    <metadata prefix="bar: http://example.org/bar">
+                        <link rel="bar:bar" href="http://example.org/bar"/>
+                    </metadata>
+                </wrapper>
+            </x:context>
+            <x:expect label="prefix declarations are merged"
+                test="//opf:metadata/@prefix = 'foo: http://example.org/foo bar: http://example.org/bar'"
+            />
+        </x:scenario>
+    </x:scenario>
+
+</x:description>


### PR DESCRIPTION
- OPF metadata is obtained by merging the `metadata` sequence port
- merging is done in XSLT (extensively tested)
- default metadata is piped as the last documenet to the merge step

@josteinaj feel free to review if you want, or directly merge. The XSLT is extensively tested, see tests and inline 'documenting' comments for what it does.
