### PR TITLE
Fix issue 379 - regression with page links

### DIFF
--- a/epub3-nav-utils/src/main/resources/xml/xslt/html5-to-page-list.xsl
+++ b/epub3-nav-utils/src/main/resources/xml/xslt/html5-to-page-list.xsl
@@ -4,17 +4,17 @@
 
     <xsl:output indent="yes"/>
 
-    <xsl:param name="base-uri" select="base-uri(/)"/>
+    <xsl:param name="base-uri" select="base-uri(/*)"/>
 
     <xsl:variable name="base-ref">
         <xsl:variable name="base-dir" select="replace($base-uri,'/[^/]*(#.*)?$','/')"/>
         <xsl:choose>
-            <xsl:when test="starts-with(base-uri(/),$base-dir)">
-                <xsl:value-of select="concat(substring-after(base-uri(/),$base-dir),'#')"/>
+            <xsl:when test="starts-with(base-uri(/*),$base-dir)">
+                <xsl:value-of select="concat(substring-after(base-uri(/*),$base-dir),'#')"/>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:message
-                    select="concat('Document base URI [',base-uri(/),'] is not relative to the given base URI [',$base-uri,']')"/>
+                    select="concat('Document base URI [',base-uri(/*),'] is not relative to the given base URI [',$base-uri,']')"/>
                 <xsl:value-of select="concat(base-uri(/),'#')"/>
             </xsl:otherwise>
         </xsl:choose>


### PR DESCRIPTION
See [issue 379](https://code.google.com/p/daisy-pipeline/issues/detail?id=379) on google code.

Relative links were not correctly computed when the base URI passed as
parameter was that of the document and not its parent directory.

Rather than forcing caller (the XProc script) to always pass a URI of a directory, the XSLT
now systematically computes the URI of the directory from the URI passed
as the `base-uri` parameter.

@josteinaj please quickly review, this should fix the regression  reported by Benetech.
