### PR TITLE
Allow non-linear spine items in epub3-pub-utils

### DIFF
--- a/epub3-pub-utils/src/main/resources/xml/xproc/create-package-doc.idref-fileset-to-spine.xsl
+++ b/epub3-pub-utils/src/main/resources/xml/xproc/create-package-doc.idref-fileset-to-spine.xsl
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" xmlns="http://www.idpf.org/2007/opf" exclude-result-prefixes="#all">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+    xmlns="http://www.idpf.org/2007/opf" exclude-result-prefixes="#all">
     <xsl:output indent="yes"/>
     <xsl:template match="/*">
         <spine>
             <xsl:for-each select="*">
-                <itemref idref="{@idref}" id="itemref_{position()}"/>
+                <itemref idref="{@idref}" id="itemref_{position()}">
+                    <xsl:if test="@linear">
+                        <xsl:attribute name="linear" select="@linear"/>
+                    </xsl:if>
+                </itemref>
             </xsl:for-each>
         </spine>
     </xsl:template>

--- a/epub3-pub-utils/src/main/resources/xml/xproc/create-package-doc.xpl
+++ b/epub3-pub-utils/src/main/resources/xml/xproc/create-package-doc.xpl
@@ -407,15 +407,29 @@
 
     <p:group name="spine">
         <p:output port="result"/>
-        <p:identity>
+        <p:group name="content-docs-primary">
+            <p:output port="result"/>
+            <px:fileset-filter media-types="application/xhtml+xml">
+                <p:input port="source">
+                    <p:pipe port="result" step="spine-filesets-with-mediatypes"/>
+                </p:input>
+            </px:fileset-filter>
+        </p:group>
+        <p:group name="content-docs-resources">
+            <p:output port="result"/>
+            <px:fileset-filter media-types="application/xhtml+xml">
+                <p:input port="source">
+                    <p:pipe port="publication-resources" step="main"/>
+                </p:input>
+            </px:fileset-filter>
+            <p:add-attribute match="/d:fileset/d:file" attribute-name="linear" attribute-value="no"/>
+        </p:group>    
+        <px:fileset-join>
             <p:input port="source">
-                <p:pipe port="result" step="spine-filesets-with-mediatypes"/>
+                <p:pipe port="result" step="content-docs-primary"/>
+                <p:pipe port="result" step="content-docs-resources"/>
             </p:input>
-        </p:identity>
-        <p:for-each>
-            <p:delete match="/d:fileset/d:file[not(@media-type='application/xhtml+xml')]"/>
-        </p:for-each>
-        <px:fileset-join/>
+        </px:fileset-join>
         <p:group>
             <p:viewport match="/*/d:file">
                 <p:variable name="file-uri" select="/*/resolve-uri(@href,base-uri(.))"/>


### PR DESCRIPTION
- `px:epub3-pub-create-package-doc` adds XHTML Content Docs from the
  publication resources to the spine, as non-linear items. This follows
  a change introduced in EPUB 3.0.1
- any entry from the "spine" manifests can be marked with the `linear`
  attribute, which will be copied to the spine `itemref` elements.
