### PR TITLE
Making epubcheck-adapter work with Saxon 9.5

### DIFF
--- a/epubcheck-adapter/pom.xml
+++ b/epubcheck-adapter/pom.xml
@@ -16,34 +16,12 @@
 
   <name>DAISY Pipeline 2 module :: EpubCheck Adapter</name>
 
-  <!--<repositories>
-      <repository>
-          <id>central</id>
-          <name>Maven Central</name>
-          <url>http://repo.maven.apache.org/maven2/</url>
-      </repository>
-  </repositories>-->
-
-  <!--<pluginRepositories>
-      <pluginRepository>
-          <id>sonatype-nexus-snapshots</id>
-          <name>oss.sonatype.org github Release Repository Snapshot Repository</name>
-          <releases>
-              <enabled>false</enabled>
-          </releases>
-          <snapshots>
-              <enabled>true</enabled>
-          </snapshots>
-          <url>http://oss.sonatype.org/content/repositories/snapshots/</url>
-      </pluginRepository>
-  </pluginRepositories>-->
-
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>org.daisy.pipeline</groupId>
         <artifactId>framework-bom</artifactId>
-        <version>1.8</version>
+        <version>1.8.1-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -61,8 +39,24 @@
     <dependency>
   	  <groupId>org.idpf</groupId>
   	  <artifactId>epubcheck</artifactId>
-  	  <version>3.0.1</version>
+      <version>3.0.1</version>
   	</dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>13.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.4.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.tukaani</groupId>
+          <artifactId>xz</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>
@@ -74,7 +68,7 @@
         <configuration>
           <instructions>
             <Import-Package>org.daisy.pipeline.script,*</Import-Package>
-            <Service-Component>OSGI-INF/epubcheck.xml</Service-Component>
+            <Service-Component>OSGI-INF/epubcheck.xml,OSGI-INF/column-number.xml,OSGI-INF/line-number.xml,OSGI-INF/system-id.xml</Service-Component>
           </instructions>
         </configuration>
       </plugin>

--- a/epubcheck-adapter/pom.xml
+++ b/epubcheck-adapter/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
   	  <groupId>org.idpf</groupId>
   	  <artifactId>epubcheck</artifactId>
-      <version>4.0.0-alpha9-SNAPSHOT</version>
+      <version>4.0.0-alpha11</version>
   	</dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/epubcheck-adapter/pom.xml
+++ b/epubcheck-adapter/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
   	  <groupId>org.idpf</groupId>
   	  <artifactId>epubcheck</artifactId>
-      <version>4.0.0-alpha11</version>
+      <version>4.0.0-alpha12</version>
   	</dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/epubcheck-adapter/pom.xml
+++ b/epubcheck-adapter/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
   	  <groupId>org.idpf</groupId>
   	  <artifactId>epubcheck</artifactId>
-      <version>3.0.1</version>
+      <version>4.0.0-alpha9-SNAPSHOT</version>
   	</dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.4.1</version>
+      <version>1.8.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.tukaani</groupId>

--- a/epubcheck-adapter/src/main/java/org/daisy/pipeline/epub/EpubCheckProvider.java
+++ b/epubcheck-adapter/src/main/java/org/daisy/pipeline/epub/EpubCheckProvider.java
@@ -2,13 +2,11 @@ package org.daisy.pipeline.epub;
 
 import java.io.File;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.HashMap;
 
 import net.sf.saxon.s9api.QName;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.XdmNode;
-
 import org.daisy.common.xproc.calabash.XProcStepProvider;
 
 import com.xmlcalabash.core.XProcException;
@@ -69,7 +67,7 @@ public class EpubCheckProvider implements XProcStepProvider {
 
 		documentValidatorFactoryMap = map;
 	}
-
+	
 	public XProcStep newStep(XProcRuntime runtime, XAtomicStep step) {
 		return new EpubCheckStep(runtime, step);
 	}

--- a/epubcheck-adapter/src/main/java/org/idpf/epubcheck/util/saxon95/ColumnNumberFunction.java
+++ b/epubcheck-adapter/src/main/java/org/idpf/epubcheck/util/saxon95/ColumnNumberFunction.java
@@ -1,0 +1,71 @@
+package org.idpf.epubcheck.util.saxon95;
+
+import net.sf.saxon.expr.XPathContext;
+import net.sf.saxon.lib.ExtensionFunctionCall;
+import net.sf.saxon.lib.ExtensionFunctionDefinition;
+import net.sf.saxon.om.NodeInfo;
+import net.sf.saxon.om.Sequence;
+import net.sf.saxon.om.StructuredQName;
+import net.sf.saxon.trans.XPathException;
+import net.sf.saxon.value.Int64Value;
+import net.sf.saxon.value.SequenceType;
+
+public class ColumnNumberFunction extends ExtensionFunctionDefinition {
+
+	private static final long serialVersionUID = -4202710868367933385L;
+
+	public static StructuredQName QNAME = new StructuredQName("saxon", "http://saxon.sf.net/", "column-number");
+	
+	@Override
+	public StructuredQName getFunctionQName() {
+		return QNAME;
+	}
+
+	@Override
+	public int getMaximumNumberOfArguments() {
+		return 1;
+	}
+
+	@Override
+	public int getMinimumNumberOfArguments() {
+		return 0;
+	}
+
+	@Override
+	public SequenceType[] getArgumentTypes() {
+		return new SequenceType[] { SequenceType.SINGLE_NODE };
+	}
+
+	@Override
+	public SequenceType getResultType(SequenceType[] suppliedArgumentTypes) {
+		return SequenceType.SINGLE_INTEGER;
+	}
+
+	@Override
+	public boolean dependsOnFocus() {
+		return true;
+	}
+
+	@Override
+	public boolean trustResultType() {
+		return true;
+	}
+
+	@Override
+	public ExtensionFunctionCall makeCallExpression() {
+		return new ExtensionFunctionCall() {
+
+			private static final long serialVersionUID = -4202710868367933385L;
+
+			public Sequence call(XPathContext context, Sequence[] arguments) throws XPathException {
+				if (context.getContextItem() instanceof NodeInfo) {
+					return new Int64Value(
+							((NodeInfo) context.getContextItem())
+									.getColumnNumber());
+				}
+				throw new XPathException(
+						"Unexpected XPath context for saxon:column-number");
+			}
+		};
+	}
+}

--- a/epubcheck-adapter/src/main/java/org/idpf/epubcheck/util/saxon95/LineNumberFunction.java
+++ b/epubcheck-adapter/src/main/java/org/idpf/epubcheck/util/saxon95/LineNumberFunction.java
@@ -1,0 +1,71 @@
+package org.idpf.epubcheck.util.saxon95;
+
+import net.sf.saxon.expr.XPathContext;
+import net.sf.saxon.lib.ExtensionFunctionCall;
+import net.sf.saxon.lib.ExtensionFunctionDefinition;
+import net.sf.saxon.om.NodeInfo;
+import net.sf.saxon.om.Sequence;
+import net.sf.saxon.om.StructuredQName;
+import net.sf.saxon.trans.XPathException;
+import net.sf.saxon.value.Int64Value;
+import net.sf.saxon.value.SequenceType;
+
+public class LineNumberFunction extends ExtensionFunctionDefinition {
+
+	private static final long serialVersionUID = -4202710868367933385L;
+	
+	public static StructuredQName QNAME = new StructuredQName("saxon", "http://saxon.sf.net/", "line-number");
+
+	@Override
+	public StructuredQName getFunctionQName() {
+		return QNAME;
+	}
+
+	@Override
+	public int getMaximumNumberOfArguments() {
+		return 1;
+	}
+
+	@Override
+	public int getMinimumNumberOfArguments() {
+		return 0;
+	}
+
+	@Override
+	public SequenceType[] getArgumentTypes() {
+		return new SequenceType[] { SequenceType.SINGLE_NODE };
+	}
+
+	@Override
+	public SequenceType getResultType(SequenceType[] suppliedArgumentTypes) {
+		return SequenceType.SINGLE_INTEGER;
+	}
+
+	@Override
+	public boolean dependsOnFocus() {
+		return true;
+	}
+
+	@Override
+	public boolean trustResultType() {
+		return true;
+	}
+
+	@Override
+	public ExtensionFunctionCall makeCallExpression() {
+		return new ExtensionFunctionCall() {
+
+			private static final long serialVersionUID = -4202710868367933385L;
+
+			public Sequence call(XPathContext context, Sequence[] arguments) throws XPathException {
+				if (context.getContextItem() instanceof NodeInfo) {
+					return new Int64Value(
+							((NodeInfo) context.getContextItem())
+									.getLineNumber());
+				}
+				throw new XPathException(
+						"Unexpected XPath context for saxon:line-number");
+			}
+		};
+	}
+}

--- a/epubcheck-adapter/src/main/java/org/idpf/epubcheck/util/saxon95/SystemIdFunction.java
+++ b/epubcheck-adapter/src/main/java/org/idpf/epubcheck/util/saxon95/SystemIdFunction.java
@@ -1,0 +1,70 @@
+package org.idpf.epubcheck.util.saxon95;
+
+import net.sf.saxon.expr.XPathContext;
+import net.sf.saxon.lib.ExtensionFunctionCall;
+import net.sf.saxon.lib.ExtensionFunctionDefinition;
+import net.sf.saxon.om.NodeInfo;
+import net.sf.saxon.om.Sequence;
+import net.sf.saxon.om.StructuredQName;
+import net.sf.saxon.trans.XPathException;
+import net.sf.saxon.value.AnyURIValue;
+import net.sf.saxon.value.SequenceType;
+
+public class SystemIdFunction extends ExtensionFunctionDefinition {
+
+	private static final long serialVersionUID = -4202710868367933385L;
+
+	public static StructuredQName QNAME = new StructuredQName("saxon", "http://saxon.sf.net/", "system-id");
+	
+	@Override
+	public StructuredQName getFunctionQName() {
+		return QNAME;
+	}
+
+	@Override
+	public int getMaximumNumberOfArguments() {
+		return 0;
+	}
+
+	@Override
+	public int getMinimumNumberOfArguments() {
+		return 0;
+	}
+
+	@Override
+	public SequenceType[] getArgumentTypes() {
+		return new SequenceType[] {};
+	}
+
+	@Override
+	public SequenceType getResultType(SequenceType[] suppliedArgumentTypes) {
+		return SequenceType.SINGLE_STRING;
+	}
+
+	@Override
+	public boolean dependsOnFocus() {
+		return true;
+	}
+
+	@Override
+	public boolean trustResultType() {
+		return true;
+	}
+
+	@Override
+	public ExtensionFunctionCall makeCallExpression() {
+		return new ExtensionFunctionCall() {
+
+			private static final long serialVersionUID = -4202710868367933385L;
+
+			public Sequence call(XPathContext context, Sequence[] arguments) throws XPathException {
+				if (context.getContextItem() instanceof NodeInfo) {
+					return new AnyURIValue(
+							((NodeInfo) context.getContextItem()).getSystemId());
+				}
+				throw new XPathException(
+						"Unexpected XPath context for saxon:line-number");
+			}
+		};
+	}
+}

--- a/epubcheck-adapter/src/main/java/org/idpf/epubcheck/util/saxon95/SystemIdFunction.java
+++ b/epubcheck-adapter/src/main/java/org/idpf/epubcheck/util/saxon95/SystemIdFunction.java
@@ -63,7 +63,7 @@ public class SystemIdFunction extends ExtensionFunctionDefinition {
 							((NodeInfo) context.getContextItem()).getSystemId());
 				}
 				throw new XPathException(
-						"Unexpected XPath context for saxon:line-number");
+						"Unexpected XPath context for saxon:system-id");
 			}
 		};
 	}

--- a/epubcheck-adapter/src/main/resources/OSGI-INF/column-number.xml
+++ b/epubcheck-adapter/src/main/resources/OSGI-INF/column-number.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" xmlns:saxon="http://saxon.sf.net/" name="saxon:column-number">
+    <scr:implementation class="idpf.epubcheck.util.saxon95.ColumnNumberFunction"/>
+    <scr:service>
+        <scr:provide interface="net.sf.saxon.lib.ExtensionFunctionDefinition"/>
+    </scr:service>
+</scr:component>

--- a/epubcheck-adapter/src/main/resources/OSGI-INF/epubcheck.xml
+++ b/epubcheck-adapter/src/main/resources/OSGI-INF/epubcheck.xml
@@ -4,5 +4,5 @@
    <service>
       <provide interface="org.daisy.common.xproc.calabash.XProcStepProvider"/>
    </service>
-   <property name="type" type="String" value="{http://www.daisy.org/ns/pipeline/xproc/internal/epubcheck-adapter}epubcheck"/>
+   <property name="type" type="String" value="{http://www.daisy.org/ns/pipeline/xproc/internal}epubcheck"/>
 </scr:component>

--- a/epubcheck-adapter/src/main/resources/OSGI-INF/line-number.xml
+++ b/epubcheck-adapter/src/main/resources/OSGI-INF/line-number.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" xmlns:saxon="http://saxon.sf.net/" name="saxon:line-number">
+    <scr:implementation class="idpf.epubcheck.util.saxon95.LineNumberFunction"/>
+    <scr:service>
+        <scr:provide interface="net.sf.saxon.lib.ExtensionFunctionDefinition"/>
+    </scr:service>
+</scr:component>

--- a/epubcheck-adapter/src/main/resources/OSGI-INF/system-id.xml
+++ b/epubcheck-adapter/src/main/resources/OSGI-INF/system-id.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" xmlns:saxon="http://saxon.sf.net/" name="saxon:system-id">
+    <scr:implementation class="idpf.epubcheck.util.saxon95.SystemIdFunction"/>
+    <scr:service>
+        <scr:provide interface="net.sf.saxon.lib.ExtensionFunctionDefinition"/>
+    </scr:service>
+</scr:component>

--- a/epubcheck-adapter/src/main/resources/xml/xproc/library.xpl
+++ b/epubcheck-adapter/src/main/resources/xml/xproc/library.xpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:library xmlns:p="http://www.w3.org/ns/xproc" xmlns:px="http://www.daisy.org/ns/pipeline/xproc" xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal/epubcheck-adapter" version="1.0"
+<p:library xmlns:p="http://www.w3.org/ns/xproc" xmlns:px="http://www.daisy.org/ns/pipeline/xproc" xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal" version="1.0"
     xmlns:c="http://www.w3.org/ns/xproc-step">
 
     <p:declare-step type="pxi:epubcheck">

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>epubcheck-adapter</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>


### PR DESCRIPTION
 * copied and fixed implementations for the functions `saxon:column-number`,  `saxon:line-number` and  `saxon:system-id` from epubcheck to epubcheck-adapter.
 * exposed functions through OSGi

This does not work currently, so don't merge. I'll create another PR for updating the pipeline-assembly dependencies once this is working.

@rdeltour is this the right approach? I'm getting the same saxon error after having added patched implementations of the saxon fuctions. Are epubcheck not seing them for some reason?

<!---
@huboard:{"order":233.5,"milestone_order":59,"custom_state":""}
-->
