### PR TITLE
Bugfix in odt:store

### DIFF
--- a/odt-utils/pom.xml
+++ b/odt-utils/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>odt-utils</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.0-p1-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DAISY Pipeline 2 module :: ODT Utils</name>

--- a/odt-utils/src/main/resources/xml/utils/normalize-uri.xpl
+++ b/odt-utils/src/main/resources/xml/utils/normalize-uri.xpl
@@ -10,7 +10,7 @@
     <p:option name="href" required="true"/>
     
     <p:xslt>
-        <p:with-param name="href" select="concat($href,'/')"/>
+        <p:with-param name="href" select="$href"/>
         <p:input port="source">
             <p:inline>
                 <c:result/>


### PR DESCRIPTION
With Calabash 1.0.18, ODT was stored at foo.odt/calabash***.zip instead of foo.odt.

@egli This fix is needed to make dtbook-to-odt work with Pipeline 1.8, but because odt-utils was already included in 1.8 I suggest we rebase this onto master and wait for the next release?
