### PR TITLE
Fix improper tagging of spine items as "non-linear"

### DIFF
--- a/epub3-pub-utils/src/main/resources/xml/xproc/create-package-doc.xpl
+++ b/epub3-pub-utils/src/main/resources/xml/xproc/create-package-doc.xpl
@@ -417,11 +417,15 @@
         </p:group>
         <p:group name="content-docs-resources">
             <p:output port="result"/>
-            <px:fileset-filter media-types="application/xhtml+xml">
+            <px:fileset-diff>
                 <p:input port="source">
                     <p:pipe port="publication-resources" step="main"/>
                 </p:input>
-            </px:fileset-filter>
+                <p:input port="secondary">
+                    <p:pipe port="result" step="spine-filesets-with-mediatypes"/>
+                </p:input>
+            </px:fileset-diff>
+            <px:fileset-filter media-types="application/xhtml+xml"/>
             <p:add-attribute match="/d:fileset/d:file" attribute-name="linear" attribute-value="no"/>
         </p:group>    
         <px:fileset-join>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <!-- <module>dtbook-utils</module> -->
     <module>epub3-nav-utils</module>
     <!-- <module>epub3-ocf-utils</module> -->
-    <!-- <module>epub3-pub-utils</module> -->
+    <module>epub3-pub-utils</module>
     <!-- <module>epubcheck-adapter</module> -->
     <module>html-utils</module>
     <module>mediaoverlay-utils</module>
@@ -82,7 +82,7 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>epub3-pub-utils</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>


### PR DESCRIPTION
When a regular Content Document was present both in the resource file
set and in the spine fileset, it was annotated as `non-linear` in the
spine. This change set fixes that by diffing the primary file set when
computing the set of non-linear content docs.