### PR TITLE
Fix issue in epubcheck-adapter: MissingFormatArgumentException

### DIFF
--- a/epubcheck-adapter/src/main/java/org/daisy/pipeline/epub/EpubCheckProvider.java
+++ b/epubcheck-adapter/src/main/java/org/daisy/pipeline/epub/EpubCheckProvider.java
@@ -21,6 +21,7 @@ import com.adobe.epubcheck.api.EpubCheck;
 import com.adobe.epubcheck.api.EpubCheckFactory;
 import com.adobe.epubcheck.api.Report;
 import com.adobe.epubcheck.api.EPUBLocation;
+import com.adobe.epubcheck.api.EPUBProfile;
 import com.adobe.epubcheck.messages.Message;
 import com.adobe.epubcheck.messages.Severity;
 import com.adobe.epubcheck.nav.NavCheckerFactory;
@@ -130,7 +131,7 @@ public class EpubCheckProvider implements XProcStepProvider {
 					xmlReport.info(null, FeatureEnum.TOOL_DATE, toolDate);
 
 				if (mode != null) {
-					xmlReport.info(null, FeatureEnum.EXEC_MODE, String.format(Messages.get("single_file"), mode, epubVersion.toString()));
+					xmlReport.info(null, FeatureEnum.EXEC_MODE, String.format(Messages.get("single_file"), mode, epubVersion.toString(), EPUBProfile.DEFAULT));
 
 					if ("expanded".equals(mode) || "exp".equals(mode)) {
 						epub = new Archive(path, false);

--- a/epubcheck-adapter/src/test/java/XProcSpecTest.java
+++ b/epubcheck-adapter/src/test/java/XProcSpecTest.java
@@ -1,0 +1,28 @@
+import org.daisy.pipeline.junit.AbstractXSpecAndXProcSpecTest;
+
+import static org.daisy.pipeline.pax.exam.Options.mavenBundle;
+
+import org.ops4j.pax.exam.Configuration;
+import static org.ops4j.pax.exam.CoreOptions.composite;
+import static org.ops4j.pax.exam.CoreOptions.options;
+import org.ops4j.pax.exam.Option;
+
+public class XProcSpecTest extends AbstractXSpecAndXProcSpecTest {
+	
+	protected String[] testDependencies() {
+		return new String[] {
+			"org.daisy.pipeline:calabash-adapter:?",
+			"org.idpf:epubcheck:?"
+		};
+	}
+	
+	@Override @Configuration
+	public Option[] config() {
+		return options(
+			// FIXME: second version of guava needed for epubcheck-adapter
+			mavenBundle("com.google.guava:guava:14.0.1"),
+			// FIXME: epubcheck needs older version of jing
+			mavenBundle("org.daisy.libs:jing:20120724.0.0"),
+			composite(super.config()));
+	}
+}

--- a/epubcheck-adapter/src/test/resources/config-calabash.xml
+++ b/epubcheck-adapter/src/test/resources/config-calabash.xml
@@ -1,0 +1,20 @@
+<!--*- nxml -*-->
+<xproc-config xmlns="http://xmlcalabash.com/ns/configuration"
+	      xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
+>
+
+<implementation type="px:copy" class-name="com.xmlcalabash.extensions.fileutils.Copy"/>
+<implementation type="px:cwd" class-name="com.xmlcalabash.extensions.osutils.Cwd"/>
+<implementation type="px:delete" class-name="com.xmlcalabash.extensions.fileutils.Delete"/>
+<implementation type="px:head" class-name="com.xmlcalabash.extensions.fileutils.Head"/>
+<implementation type="px:info" class-name="com.xmlcalabash.extensions.fileutils.Info"/>
+<implementation type="px:mkdir" class-name="com.xmlcalabash.extensions.fileutils.Mkdir"/>
+<implementation type="px:move" class-name="com.xmlcalabash.extensions.fileutils.Move"/>
+<implementation type="px:tail" class-name="com.xmlcalabash.extensions.fileutils.Tail"/>
+<implementation type="px:tempfile" class-name="com.xmlcalabash.extensions.fileutils.Tempfile"/>
+<implementation type="px:touch" class-name="com.xmlcalabash.extensions.fileutils.Touch"/>
+<implementation type="px:unzip" class-name="com.xmlcalabash.extensions.Unzip"/>
+<implementation type="px:zip" class-name="com.xmlcalabash.extensions.Zip"/>
+
+
+</xproc-config>

--- a/epubcheck-adapter/src/test/resources/exam.properties
+++ b/epubcheck-adapter/src/test/resources/exam.properties
@@ -1,0 +1,1 @@
+pax.exam.logging = none

--- a/epubcheck-adapter/src/test/resources/logback.xml
+++ b/epubcheck-adapter/src/test/resources/logback.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+   
+  <appender name="TEST_LOG" class="ch.qos.logback.core.FileAppender">
+    <file>target/test.log</file>
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  
+  <root level="WARNING">
+    <appender-ref ref="TEST_LOG"/>
+  </root>
+  
+  <logger name="org.daisy" level="DEBUG"/>
+  
+</configuration>

--- a/epubcheck-adapter/src/test/resources/regression-MissingFormatArgumentException/EPUB/C00000-04-chapter.xhtml
+++ b/epubcheck-adapter/src/test/resources/regression-MissingFormatArgumentException/EPUB/C00000-04-chapter.xhtml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/#">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Valentin Haüy - the father of the education for the blind</title>
+        <meta content="C00000" name="dc:identifier" />
+    </head>
+    <body id="d910e694" epub:type="bodymatter chapter">
+        <div id="page_5" class="page-normal" epub:type="pagebreak" title="5"></div>
+        <h1 id="d910e696">Headline</h1>
+        <p>Paragraph.</p>
+    </body>
+</html>

--- a/epubcheck-adapter/src/test/resources/regression-MissingFormatArgumentException/EPUB/nav.xhtml
+++ b/epubcheck-adapter/src/test/resources/regression-MissingFormatArgumentException/EPUB/nav.xhtml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/#">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Valentin Haüy - the father of the education for the blind</title>
+        <meta content="C00000" name="dc:identifier" />
+        <meta name="viewport" content="width=device-width" />
+    </head>
+    <body>
+        <nav epub:type="toc">
+            <h1>Table of contents</h1>
+            <ol>
+                <li><a href="C00000-04-chapter.xhtml#d910e694">Headline</a></li>
+            </ol>
+        </nav>
+        <nav epub:type="page-list" hidden="">
+            <h1>List of pages</h1>
+            <ol>
+                <li><a href="C00000-04-chapter.xhtml#page_5">5</a></li>
+            </ol>
+        </nav>
+    </body>
+</html>

--- a/epubcheck-adapter/src/test/resources/regression-MissingFormatArgumentException/EPUB/package.opf
+++ b/epubcheck-adapter/src/test/resources/regression-MissingFormatArgumentException/EPUB/package.opf
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="pub-identifier" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/">
+    <metadata>
+        <dc:identifier id="pub-identifier">C00000</dc:identifier>
+        <dc:title>Valentin Haüy - the father of the education for the blind</dc:title>
+        <dc:creator>Beatrice Christensen Sköld</dc:creator>
+        <dc:language>en</dc:language>
+        <dc:source>urn:isbn:123456789</dc:source>
+        <dc:format>EPUB3</dc:format>
+        <dc:publisher>MTM</dc:publisher>
+        <dc:date>2006-03-23</dc:date>
+        <meta property="dcterms:modified">2013-11-07T10:05:30Z</meta>
+    </metadata>
+    <manifest>
+        <item id="item_13" media-type="application/xhtml+xml" href="C00000-04-chapter.xhtml"/>
+        <item id="item_20" media-type="application/xhtml+xml" href="nav.xhtml" properties="nav"/>
+    </manifest>
+    <spine>
+        <itemref id="itemref_4" idref="item_13"/>
+    </spine>
+</package>

--- a/epubcheck-adapter/src/test/resources/regression-MissingFormatArgumentException/META-INF/container.xml
+++ b/epubcheck-adapter/src/test/resources/regression-MissingFormatArgumentException/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
+    <rootfiles>
+        <rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+    </rootfiles>
+</container>

--- a/epubcheck-adapter/src/test/resources/regression-MissingFormatArgumentException/mimetype
+++ b/epubcheck-adapter/src/test/resources/regression-MissingFormatArgumentException/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/epubcheck-adapter/src/test/xprocspec/test.xprocspec
+++ b/epubcheck-adapter/src/test/xprocspec/test.xprocspec
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.daisy.org/ns/xprocspec"
+               xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
+               xmlns:d="http://www.daisy.org/ns/pipeline/data"
+               script="../../main/resources/xml/xproc/library.xpl">
+    
+    <x:scenario label="regression for error: java.util.MissingFormatArgumentException: Format specifier '%3$s'">
+        <x:call step="px:epubcheck">
+            <x:option name="mode" select="'expanded'"/>
+            <x:option name="version" select="'3'"/>
+            <x:option name="epub" select="resolve-uri('../resources/regression-MissingFormatArgumentException/EPUB/package.opf')"/>
+        </x:call>
+        <x:context label="the result port">
+            <x:document type="port" port="result"/>
+        </x:context>
+        <x:expect label="there should be a result document" type="count" min-count="1"/>
+    </x:scenario>
+    
+</x:description>


### PR DESCRIPTION
```
java.util.MissingFormatArgumentException: Format specifier '%3$s'
```

This exception appears if you try to validate an unzipped EPUB (i.e. passing in a reference to the OPF instead of an EPUB).